### PR TITLE
fix(FilterableDialogFragment): correct hint text

### DIFF
--- a/dhis2-android-app/src/main/java/org/dhis2/mobile/ui/fragments/FilterableDialogFragment.java
+++ b/dhis2-android-app/src/main/java/org/dhis2/mobile/ui/fragments/FilterableDialogFragment.java
@@ -111,6 +111,7 @@ public class FilterableDialogFragment extends DialogFragment {
 
         EditText filterEditText = (EditText) view
                 .findViewById(R.id.edittext_filter_picker_items);
+        filterEditText.setHint(R.string.search);
         filterEditText.addTextChangedListener(new TextWatcher() {
 
             @Override

--- a/dhis2-android-app/src/main/res/values/strings.xml
+++ b/dhis2-android-app/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="choose_program">Choose program</string>
     <string name="choose_unit">Choose organisation unit</string>
     <string name="choose_period">Choose period</string>
+    <string name="search">Search</string>
 
     <!-- String resources for single event without registration fragment -->
     <string name="longitude">Longitude</string>


### PR DESCRIPTION
Before:

![screenshot_20160930-113805](https://cloud.githubusercontent.com/assets/3536066/18987945/999c1f6e-8704-11e6-92e8-6dada523bfff.png)

After:

![screenshot_20160930-114512](https://cloud.githubusercontent.com/assets/3536066/18987949/9ee65976-8704-11e6-9954-d3e11e831ae3.png)

